### PR TITLE
Add DOM test and Node-friendly setup

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const board = document.getElementById('board');
+const board = typeof document !== 'undefined' ? document.getElementById('board') : null;
 
 function createTiles(rows = 6, cols = 5) {
     for (let r = 0; r < rows; r++) {
@@ -20,9 +20,10 @@ let currentCol = 0; // index within the active row
 const MAX_ROWS = 6;
 const MAX_COLS = 5;
 
-createTiles(MAX_ROWS, MAX_COLS); // initialize the board
-
-document.addEventListener('keydown', handleKeyPress);
+if (board) {
+    createTiles(MAX_ROWS, MAX_COLS); // initialize the board
+    document.addEventListener('keydown', handleKeyPress);
+}
 
 /**
  * Stub validation function. Replace with real dictionary logic.
@@ -104,4 +105,18 @@ function flashInvalidRow() {
     setTimeout(() => {
         row.style.backgroundColor = original;
     }, 500);
+}
+
+// Export functions for testing in Node
+if (typeof module !== 'undefined') {
+    module.exports = {
+        createTiles,
+        handleKeyPress,
+        eraseLetter,
+        placeLetter,
+        submitRow,
+        getCurrentWord,
+        flashInvalidRow,
+        board
+    };
 }

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@
     justify-content: center;
     font-size: 2rem;
     text-transform: uppercase;
+    box-sizing: border-box;
 }
 
 @media (max-width: 600px) {

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -1,0 +1,61 @@
+class Element {
+  constructor(tagName) {
+    this.tagName = tagName;
+    this.children = [];
+    this.textContent = '';
+    this.className = '';
+    this.style = {};
+    this._id = '';
+    this.ownerDocument = null;
+  }
+  appendChild(child) {
+    this.children.push(child);
+    child.ownerDocument = this.ownerDocument;
+  }
+  set id(value) {
+    this._id = value;
+    if (this.ownerDocument) {
+      this.ownerDocument._elements[value] = this;
+    }
+  }
+  get id() {
+    return this._id;
+  }
+}
+
+class Document {
+  constructor() {
+    this.body = new Element('body');
+    this.body.ownerDocument = this;
+    this._elements = {};
+  }
+  createElement(tagName) {
+    const el = new Element(tagName);
+    el.ownerDocument = this;
+    return el;
+  }
+  getElementById(id) {
+    return this._elements[id] || null;
+  }
+  addEventListener() {
+    // no-op for tests
+  }
+}
+
+global.document = new Document();
+
+const board = document.createElement('div');
+board.id = 'board';
+document.body.appendChild(board);
+
+require('../script.js');
+
+const rows = board.children.length;
+const cols = rows > 0 ? board.children[0].children.length : 0;
+
+if (rows === 6 && cols === 5) {
+  console.log('✅ DOM test passed');
+} else {
+  console.error('❌ DOM test failed');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a minimal DOM test
- support running script.js in Node
- ensure tiles size correctly

## Testing
- `node tests/dom.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683fbc67e43c8332a395ac37cc77b931